### PR TITLE
Throw a meaningful error when database is invalid.

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,11 +53,22 @@ var streamListener = function(parser, writer, supportMetadata){
     var collectionNameForFiles = new RegExp('.*/([^/]+)/[^/]+$');
     var metadataFilenameRegexp = new RegExp('.*/[^/]+/([^/]+)$');
 
+    var getCollectionForFile =  function (regex, path) {
+        var execArr = regex.exec(path);
+        if (execArr && execArr.length > 1) {
+            return execArr[1];
+        } else {
+            throw Error('Invalid database structure');
+        }
+    };
+
+    var getMetaDataName = getCollectionForFile;
+
     var metadata = [];
     return {
         onDirectory: function (directoryName, callback) {
             // Parse collection name out
-            var collectionName = collectionNameForDirectory.exec(directoryName.replace(/\\/g, '/'))[1];
+            var collectionName = getCollectionForFile(collectionNameForDirectory, directoryName.replace(/\\/g, '/'));
             if (collectionName === '.metadata') {
                 callback(null);
                 return;
@@ -66,10 +77,10 @@ var streamListener = function(parser, writer, supportMetadata){
         },
 
         onFile: function(name, stream, callback) {
-            var collectionName = collectionNameForFiles.exec(name.replace(/\\/g, '/'))[1];
+            var collectionName = getCollectionForFile(collectionNameForFiles, name.replace(/\\/g, '/'));
             if (collectionName === '.metadata') {
                 // Extract metadata collection name
-                var metadataName = metadataFilenameRegexp.exec(name.replace(/\\/g, '/'))[1];
+                var metadataName = getMetaDataName(metadataFilenameRegexp, name.replace(/\\/g, '/'));
                 //parse the metadata file
 
                 // Callback and return only if metadata support disabled

--- a/index.min.js
+++ b/index.min.js
@@ -176,16 +176,22 @@ function restore(options) {
 }
 
 var systemRegex = /^system\./, fs = require("graceful-fs"), path = require("path"), logger, streamListener = function(parser, writer, supportMetadata) {
-    var collectionNameForDirectory = new RegExp(".*/([^/]+)/?$"), collectionNameForFiles = new RegExp(".*/([^/]+)/[^/]+$"), metadataFilenameRegexp = new RegExp(".*/[^/]+/([^/]+)$"), metadata = [];
+    var collectionNameForDirectory = new RegExp(".*/([^/]+)/?$"), collectionNameForFiles = new RegExp(".*/([^/]+)/[^/]+$"), metadataFilenameRegexp = new RegExp(".*/[^/]+/([^/]+)$"), getCollectionForFile = function(regex, path) {
+        var execArr = regex.exec(path);
+        if (execArr && execArr.length > 1) return execArr[1];
+        throw Error("Invalid database structure");
+    }, getMetaDataName = function(regex, path) {
+        return getCollectionForFile(regex, path);
+    }, metadata = [];
     return {
         onDirectory: function(directoryName, callback) {
-            var collectionName = collectionNameForDirectory.exec(directoryName.replace(/\\/g, "/"))[1];
+            var collectionName = getCollectionForFile(collectionNameForDirectory, directoryName.replace(/\\/g, "/"));
             ".metadata" !== collectionName ? writer.createCollection(collectionName, callback) : callback(null);
         },
         onFile: function(name, stream, callback) {
-            var collectionName = collectionNameForFiles.exec(name.replace(/\\/g, "/"))[1];
+            var collectionName = getCollectionForFile(collectionNameForFiles, name.replace(/\\/g, "/"));
             if (".metadata" === collectionName) {
-                var metadataName = metadataFilenameRegexp.exec(name.replace(/\\/g, "/"))[1];
+                var metadataName = getMetaDataName(metadataFilenameRegexp, name.replace(/\\/g, "/"));
                 if (!supportMetadata) return void callback(null);
             }
             var buffers = [];

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.3",
+  "version": "1.6.4",
   "name": "mongodb-restore-streaming",
   "description": "restore data from mongodb-backup (fork from https://github.com/hex7c0/mongodb-restore)",
   "keywords": [


### PR DESCRIPTION
Previously, when path validation checks failed for directories, files,
or metadata files read from a stream, a user unfriendly error was
thrown.